### PR TITLE
SG-43664 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -67,6 +67,7 @@ description: "Automate the build of your scene by helping retrieving and loading
 requires_shotgun_version:
 requires_core_version: "v0.19.1"
 requires_engine_version:
+minimum_python_version: "3.9"
 
 # the frameworks required to run this app
 frameworks:

--- a/python/tk_multi_scenebuilder/model.py
+++ b/python/tk_multi_scenebuilder/model.py
@@ -39,7 +39,7 @@ class FileModel(QtGui.QStandardItemModel, ViewItemRolesMixin):
         NEXT_AVAILABLE_ROLE,
     ) = range(_BASE_ROLE, _BASE_ROLE + 7)
 
-    (STATUS_UP_TO_DATE, STATUS_OUTDATED, STATUS_NOT_LOADED, STATUS_INVALID) = range(4)
+    STATUS_UP_TO_DATE, STATUS_OUTDATED, STATUS_NOT_LOADED, STATUS_INVALID = range(4)
 
     GROUP_NAMES = {
         STATUS_UP_TO_DATE: "Loaded",
@@ -165,7 +165,7 @@ class FileModel(QtGui.QStandardItemModel, ViewItemRolesMixin):
         self._parent_items = {}
         self._pending_requests = {}
 
-        super(FileModel, self).clear()
+        super().clear()
 
     def destroy(self):
         """


### PR DESCRIPTION
## Summary
- Set `minimum_python_version: "3.9"` in `info.yml`
- Modernised `super()` call in `model.py`

## Test plan
- [ ] Pre-commit passes (black, check-ast, check-yaml, whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)